### PR TITLE
src: add nullish coalescing operator

### DIFF
--- a/src/optimize/logicalExpressionReduction.js
+++ b/src/optimize/logicalExpressionReduction.js
@@ -2,6 +2,9 @@ const isGlobalProperty = require('./utilities/isGlobalProperty')
 
 const LOGICAL_OPERATORS = ['&&', '||']
 
+if (Number(process.version.split('.')[0].slice(1)) >= 14)
+  LOGICAL_OPERATORS.push('??')
+
 function isLogicalOperator (operator) {
   return LOGICAL_OPERATORS.includes(operator)
 }
@@ -41,6 +44,7 @@ function evaluate (operator, left, right) {
   switch (operator) {
     case '&&': return serialize(left && right)
     case '||': return serialize(left || right)
+    case '??': return eval('serialize(left ?? right)')
   }
 }
 

--- a/test/optimize/logicalExpressionReduction.spec.js
+++ b/test/optimize/logicalExpressionReduction.spec.js
@@ -26,4 +26,22 @@ test('logicalExpressionReduction', assert => {
   var tree = new AbstractSyntaxTree('const foo = Infinity || "foo"')
   tree.replace(logicalExpressionReduction)
   assert.deepEqual(tree.source, 'const foo = Infinity;\n')
+  
+  if (Number(process.version.split('.')[0].slice(1)) >= 14) eval(`
+    var tree = new AbstractSyntaxTree('const foo = 1 ?? "foo"')
+    tree.replace(logicalExpressionReduction)
+    assert.deepEqual(tree.source, 'const foo = 1;\n')
+    
+    var tree = new AbstractSyntaxTree('const foo = 0 ?? Infinity')
+    tree.replace(logicalExpressionReduction)
+    assert.deepEqual(tree.source, 'const foo = 0;\n')
+    
+    var tree = new AbstractSyntaxTree('const foo = undefined ?? 5')
+    tree.replace(logicalExpressionReduction)
+    assert.deepEqual(tree.source, 'const foo = 5;\n')
+    
+    var tree = new AbstractSyntaxTree('const foo = null ?? "bar"')
+    tree.replace(logicalExpressionReduction)
+    assert.deepEqual(tree.source, 'const foo = "bar";\n')
+  `)
 })

--- a/test/optimize/logicalExpressionReduction.spec.js
+++ b/test/optimize/logicalExpressionReduction.spec.js
@@ -27,7 +27,7 @@ test('logicalExpressionReduction', assert => {
   tree.replace(logicalExpressionReduction)
   assert.deepEqual(tree.source, 'const foo = Infinity;\n')
   
-  if (Number(process.version.split('.')[0].slice(1)) >= 14) eval(`
+  if (Number(process.version.split('.')[0].slice(1)) >= 14) {
     var tree = new AbstractSyntaxTree('const foo = 1 ?? "foo"')
     tree.replace(logicalExpressionReduction)
     assert.deepEqual(tree.source, 'const foo = 1;\n')
@@ -43,5 +43,5 @@ test('logicalExpressionReduction', assert => {
     var tree = new AbstractSyntaxTree('const foo = null ?? "bar"')
     tree.replace(logicalExpressionReduction)
     assert.deepEqual(tree.source, 'const foo = "bar";\n')
-  `)
+  }
 })


### PR DESCRIPTION
Added the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) (`??`) as one of the logical operators, these will only be executed if the user's installed Node.js version is v14 or higher since the nullish coalescing operator is only supported in Node.js v14 or higher.