### PR TITLE
Fix: undefined "VisitorOption"

### DIFF
--- a/src/traverse/estraverse
+++ b/src/traverse/estraverse
@@ -23,7 +23,7 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-let Syntax, VisitorKeys, BREAK, SKIP, REMOVE
+let Syntax, VisitorKeys, BREAK, SKIP, REMOVE, VisitorOption
 
 Syntax = {
   AssignmentExpression: "AssignmentExpression",


### PR DESCRIPTION
A few versions back, after bringing "estraverse" module into the codebase, it introduced a breaking change because the variable `VisitorOption` which is used later in the file, was not added to line 26 to be declared.